### PR TITLE
Add annotation to Vault application in ArgoCD configuration

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: vault
   namespace: argocd     
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   project: core-tools
   source:


### PR DESCRIPTION
- Added the annotation 'argocd.argoproj.io/compare-options: IgnoreExtraneous' to the Vault application resource to enhance comparison behavior during sync operations.