### PR TITLE
Add ignore-differences annotation for MutatingWebhookConfiguration in…

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -6,6 +6,12 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/ignore-differences: |
+      - group: admissionregistration.k8s.io
+        kind: MutatingWebhookConfiguration
+        name: vault-agent-injector-cfg
+        jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
 spec:
   project: core-tools
   source:


### PR DESCRIPTION
… Vault application

- Added 'argocd.argoproj.io/ignore-differences' annotation to exclude changes in the caBundle of the MutatingWebhookConfiguration from being considered during sync operations, improving deployment stability.