### PR TITLE
Update Vault ingress host in ArgoCD configuration

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -17,7 +17,7 @@ spec:
             annotations:
               kubernetes.io/ingress.class: nginx
             hosts:
-              - host: vault.local
+              - host: vault.dublinconsulting.com.br
                 paths:
                 - "/"
     chart: infra/vault


### PR DESCRIPTION
- Changed the ingress host from 'vault.local' to 'vault.dublinconsulting.com.br' to reflect the new domain for the Vault application.