### PR TITLE
Add external-dns annotation for Vault ingress in ArgoCD configuration

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -16,6 +16,7 @@ spec:
             pathType: ImplementationSpecific
             annotations:
               kubernetes.io/ingress.class: nginx
+              external-dns.alpha.kubernetes.io/hostname: dublinconsulting.com.br
             hosts:
               - host: vault.dublinconsulting.com.br
                 paths:


### PR DESCRIPTION
- Added 'external-dns.alpha.kubernetes.io/hostname' annotation to the Vault ingress resource to enable DNS management for the new domain 'vault.dublinconsulting.com.br'.