### PR TITLE
Add external-secrets and external-secrets-config applications in ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/config/external-secrets-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/external-secrets-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-config
+  namespace: argocd     
+spec:
+  project: core-tools-config
+  source:
+    repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
+    path: kubernetes/argocd_cluster02/config/core-tools/external-secrets-config
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true

--- a/kubernetes/argocd_cluster02/applications/core-tools/external-secrets.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/external-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: harbor.guiadodevops.com
+    targetRevision: 0.18.2
+    chart: infra/external-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true

--- a/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   provider:
     vault:
-      server: "https://vault.guiadodevops.com"
+      server: "http://vault.dublinconsulting.com.br"
       path: "secret"
       version: "v2"
       auth:


### PR DESCRIPTION
- Created new ArgoCD application configurations for external-secrets and external-secrets-config.
- Set up automated sync policies and specified repository sources for both applications.
- Updated the secret store configuration to point to the new Vault server URL.