### PR TITLE
Add core-tools-config AppProject in ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/config/core-tools-config-project.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools-config-project.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: core-tools-config
+  namespace: argocd
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*' 


### PR DESCRIPTION
- Created a new AppProject configuration for core-tools-config in ArgoCD.
- Configured cluster resource whitelist, destination namespaces, and source repositories to allow broad access for the project.