### PR TITLE
Add cert-manager and cert-manager-config applications in ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/cert-manager.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/cert-manager.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: harbor.guiadodevops.com
+    targetRevision: v1.18.2
+    helm:
+      parameters:
+        - name: installCRDs
+          value: 'true'
+    chart: infra/cert-manager
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true

--- a/kubernetes/argocd_cluster02/applications/core-tools/config/cert-manager-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/cert-manager-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-config
+  namespace: argocd     
+spec:
+  project: core-tools-config
+  source:
+    repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
+    path: kubernetes/argocd_cluster02/config/core-tools/cert-manager-config
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true


### PR DESCRIPTION
- Created new ArgoCD application configurations for cert-manager and cert-manager-config.
- Configured automated sync policies and specified repository sources for both applications.
- Set destination namespaces to 'security' for proper resource management.