### PR TITLE
Add TLS configuration and cert-manager annotations for Vault ingress …

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -16,10 +16,16 @@ spec:
             pathType: ImplementationSpecific
             annotations:
               kubernetes.io/ingress.class: nginx
+              cert-manager.io/cluster-issuer: letsencrypt-prod
+              cert-manager.io/common-name: vault.dublinconsulting.com.br
             hosts:
               - host: vault.dublinconsulting.com.br
                 paths:
                 - "/"
+            tls:
+              - secretName: vault-tls
+                hosts:
+                  - vault.dublinconsulting.com.br
     chart: infra/vault
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
…in ArgoCD

- Added cert-manager annotations for cluster issuer and common name to the Vault ingress resource.
- Configured TLS settings with a secret name for secure communication on the specified domain.