### PR TITLE
Update cert-manager cluster issuer and Vault server URL in configurat…

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -16,7 +16,7 @@ spec:
             pathType: ImplementationSpecific
             annotations:
               kubernetes.io/ingress.class: nginx
-              cert-manager.io/cluster-issuer: letsencrypt-prod
+              cert-manager.io/cluster-issuer: letsencrypt
               cert-manager.io/common-name: vault.dublinconsulting.com.br
             hosts:
               - host: vault.dublinconsulting.com.br

--- a/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   provider:
     vault:
-      server: "https://vault.dublinconsulting.com.br"
+      server: "http://vault.dublinconsulting.com.br"
       path: "secret"
       version: "v2"
       auth:


### PR DESCRIPTION
…ions

- Changed the cert-manager cluster issuer from 'letsencrypt-prod' to 'letsencrypt' in the Vault ingress resource.
- Updated the Vault server URL from HTTPS to HTTP in the external-secrets-config.