### PR TITLE
Update Vault ingress hostname annotation for external-dns configuration

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -13,12 +13,10 @@ spec:
         server:
           ingress:
             enabled: true
-            pathType: ImplementationSpecific
             annotations:
               kubernetes.io/ingress.class: nginx
               cert-manager.io/cluster-issuer: "letsencrypt"
               external-dns.alpha.kubernetes.io/hostname: dublinconsulting.com.br
-              external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
             hosts:
               - host: vault.dublinconsulting.com.br
                 paths:


### PR DESCRIPTION
- Changed the external-dns hostname annotation to use 'vault.dublinconsulting.com.br' for improved DNS management.
- This update aligns the ingress resource with the correct domain for the Vault service.