### PR TITLE
Refactor external-dns configuration to use Cloudflare provider

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/external-dns.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/external-dns.yaml
@@ -10,85 +10,56 @@ spec:
     targetRevision: 1.17.0
     helm:
       values: |-
-        provider: aws
-        aws:
-          zoneType: public
-          region: us-east-1
-          assumeRole: ""
-          credentials:
-            secretName: external-dns-provider-aws
-            accessKeyIdKey: access-key-id
-            secretAccessKeyKey: secret-access-key
-        policy: sync
-        sources:
-          - ingress
+        # Cloudflare configuration for external-dns
+        provider:
+          name: cloudflare
+
+        # Cloudflare-specific arguments
+        extraArgs:
+          - --cloudflare-proxied
+          - --cloudflare-dns-records-per-page=100
+
+        # Environment variables for Cloudflare credentials
+        env:
+          - name: CF_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: external-dns-provider-cloudflare
+                key: CF_API_KEY
+          - name: CF_API_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: external-dns-provider-cloudflare
+                key: CF_API_EMAIL
+
+        # Domain filters (optional - limit which domains to manage)
         domainFilters:
-          - dublinconsulting.com.br
-        txtOwnerId: cluster02
-        txtPrefix: "external-dns-"
-        interval: 5m
-        logLevel: info
-        logFormat: text
+          - "dublinconsulting.com.br"
+
+        # Sources to monitor
+        sources:
+          - service
+          - ingress
+
+        # Registry type for tracking ownership
         registry: txt
-        txtCacheInterval: 0s
-        serviceAccount:
-          create: true
-          name: external-dns
-          annotations: {}
-        rbac:
-          create: true
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-        nodeSelector: {}
-        tolerations: []
-        affinity: {}
-        podAnnotations: {}
-        podSecurityContext: {}
-        securityContext: {}
-        serviceAccountAnnotations: {}
-        priorityClassName: ""
-        deploymentAnnotations: {}
-        podLabels: {}
-        serviceLabels: {}
-        serviceAnnotations: {}
-        ingress:
-          enabled: false
-        serviceMonitor:
-          enabled: false
-        prometheusRule:
-          enabled: false
-        pdb:
-          enabled: false
-        hostNetwork: false
-        dnsPolicy: ClusterFirst
-        image:
-          repository: registry.k8s.io/external-dns/external-dns
-          tag: v0.13.5
-          pullPolicy: IfNotPresent
-        imagePullSecrets: []
-        extraArgs: []
-        extraEnvs: []
-        extraVolumeMounts: []
-        extraVolumes: []
-        livenessProbe:
-          enabled: true
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-          successThreshold: 1
-        readinessProbe:
-          enabled: true
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-          successThreshold: 1
+
+        # TXT owner ID to identify records created by this instance
+        txtOwnerId: "external-dns"
+
+        # Policy for DNS record management
+        policy: upsert-only
+
+        # Update interval
+        interval: 2m
+
+        # Log level
+        logLevel: info
+
+        deploymentAnnotations:
+          reloader.stakater.com/match: "true"
+        podAnnotations:
+          reloader.stakater.com/auto: "true"
     chart: infra/external-dns
   destination:
     server: https://kubernetes.default.svc

--- a/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/vault.yaml
@@ -17,6 +17,7 @@ spec:
               kubernetes.io/ingress.class: nginx
               cert-manager.io/cluster-issuer: "letsencrypt"
               external-dns.alpha.kubernetes.io/hostname: dublinconsulting.com.br
+              external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
             hosts:
               - host: vault.dublinconsulting.com.br
                 paths:

--- a/kubernetes/argocd_cluster02/config/core-tools/cert-manager-config/cluster-issuer.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/cert-manager-config/cluster-issuer.yaml
@@ -12,15 +12,8 @@ spec:
     privateKeySecretRef:
       # Secret resource that will be used to store the account's private key.
       name: letsencrypt
-    # Add DNS-01 challenge solver for Route 53
+    # Add a single challenge solver, HTTP01 using nginx
     solvers:
-    - dns01:
-        route53:
-          region: us-east-1  # Replace with your AWS region
-          hostedZoneID: Z0137760XOTQS1KJNLL4  # Replace with your actual Route 53 hosted zone ID
-          accessKeyIDSecretRef:
-            name: aws-credentials
-            key: access-key-id
-          secretAccessKeySecretRef:
-            name: aws-credentials
-            key: secret-access-key
+    - http01:
+        ingress:
+          ingressClassName: nginx

--- a/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: external-dns-provider-aws
+  name: external-dns-provider-cloudflare
   namespace: operational
 spec:
   refreshInterval: "15s"
@@ -9,7 +9,7 @@ spec:
     name: vault
     kind: ClusterSecretStore
   target:
-    name: external-dns-provider-aws
+    name: external-dns-provider-cloudflare
   dataFrom:
     - extract:
-        key: external-dns-provider-aws
+        key: external-dns-provider-cloudflare


### PR DESCRIPTION
- Updated external-dns.yaml to switch from AWS to Cloudflare as the DNS provider, including necessary credentials and configuration.
- Modified external-secret-external-dns-providers.yaml to reflect the change in provider name and secret references.
- Adjusted Vault ingress annotations to include Cloudflare-specific settings for improved DNS management.