### PR TITLE
Update external-secret-external-dns-providers.yaml to include Cloudfl…

### DIFF
--- a/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
@@ -10,6 +10,12 @@ spec:
     kind: ClusterSecretStore
   target:
     name: external-dns-provider-cloudflare
-  dataFrom:
-    - extract:
+  data:
+    - secretKey: CF_API_KEY
+      remoteRef:
         key: external-dns-provider-cloudflare
+        property: CF_API_KEY
+    - secretKey: CF_API_EMAIL
+      remoteRef:
+        key: external-dns-provider-cloudflare
+        property: CF_API_EMAIL


### PR DESCRIPTION
…are API credentials

- Replaced deprecated 'dataFrom' configuration with 'data' to specify CF_API_KEY and CF_API_EMAIL for the Cloudflare DNS provider.
- Ensured proper secret references for improved external-dns management.