### PR TITLE
Refactor external-secret-external-dns-providers.yaml to use dataFrom …

### DIFF
--- a/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-dns-config/external-secret-external-dns-providers.yaml
@@ -10,12 +10,6 @@ spec:
     kind: ClusterSecretStore
   target:
     name: external-dns-provider-cloudflare
-  data:
-    - secretKey: CF_API_KEY
-      remoteRef:
+  dataFrom:
+    - extract:
         key: external-dns-provider-cloudflare
-        property: CF_API_KEY
-    - secretKey: CF_API_EMAIL
-      remoteRef:
-        key: external-dns-provider-cloudflare
-        property: CF_API_EMAIL

--- a/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/external-secrets-config/secret-store.yaml
@@ -7,7 +7,7 @@ spec:
   provider:
     vault:
       server: "https://vault.dublinconsulting.com.br"
-      path: "cubbyhole/"
+      path: "secret"
       version: "v2"
       auth:
         tokenSecretRef:


### PR DESCRIPTION
…for Cloudflare credentials

- Updated the configuration to replace individual secret references for CF_API_KEY and CF_API_EMAIL with a single extract from the external-dns-provider-cloudflare key.
- Modified secret-store.yaml to change the Vault path from 'cubbyhole/' to 'secret' for improved secret management.