### PR TITLE
Update Terraform variables for OCI OKE cluster to use placeholder values

### DIFF
--- a/infra-code/terraform/oci/oke-cluster/terraform.tfvars
+++ b/infra-code/terraform/oci/oke-cluster/terraform.tfvars
@@ -1,4 +1,4 @@
-compartment_ocid = "ocid1.compartment.oc1..aaaaaaaacfrcqei3rsvubbjzfgvifvczgjokyvr6hrbxb65wmzlnzsy3pfvq"
-tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaazjhsdvngrxxref2sykfxkpqonubj3i5yii6o3wv2tjy7inoqfjba"
+compartment_ocid = "ocid1.compartment.oc1.."
+tenancy_ocid = "ocid1.tenancy.oc1.."
 region = "sa-saopaulo-1"
 cluster_name = "oke-cluster-devops01"

--- a/infra-code/terraform/oci/oke-cluster/variables.tf
+++ b/infra-code/terraform/oci/oke-cluster/variables.tf
@@ -4,12 +4,12 @@ variable "region" {
 
 
 variable "tenancy_ocid" {
-  description = "ocid1.tenancy.oc1..aaaaaaaazjhsdvngrxxref2sykfxkpqonubj3i5yii6o3wv2tjy7inoqfjba"
+  description = "ocid1.tenancy.oc1.."
   type        = string
 }
 
 variable "compartment_ocid" {
-  description = "ocid1.compartment.oc1..aaaaaaaacfrcqei3rsvubbjzfgvifvczgjokyvr6hrbxb65wmzlnzsy3pfvq"
+  description = "ocid1.compartment.oc1.."
   type        = string
 }
 
@@ -26,7 +26,7 @@ variable "kubernetes_version" {
 variable "node_image_id" {
   description = "Oracle-Linux-8.10"
   type        = string
-  default     = "ocid1.image.oc1.sa-saopaulo-1.aaaaaaaasw5av4oqvhsstxjy2ddk6s2htw6r52yngdoer3ncv5zufktt5nca"
+  default     = "ocid1.image.oc1.sa-saopaulo-1."
 }
 
 variable "node_shape_id" {


### PR DESCRIPTION
- Modified 'terraform.tfvars' and 'variables.tf' to replace specific OCIDs with placeholder values for 'compartment_ocid' and 'tenancy_ocid'.
- Updated the default image ID in 'variables.tf' to a placeholder format for better clarity and security.