### PR TITLE
Add Grafana and Grafana configuration applications to ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/config/grafana-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/grafana-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana-config
+  namespace: argocd     
+spec:
+  project: core-tools-config
+  source:
+    repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
+    path: kubernetes/argocd_02/config/core-tools/grafana-config
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true

--- a/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: harbor.guiadodevops.com
+    targetRevision: 9.2.10
+    helm:
+      values: |-
+        ingress:
+          enabled: true
+          ingressClassName: nginx
+          annotations:
+            cert-manager.io/cluster-issuer: "letsencrypt"
+            external-dns.alpha.kubernetes.io/hostname: dublinconsulting.com.br
+            external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          hosts:
+            - grafana.dublinconsulting.com.br
+          path: /
+          tls:
+          - secretName: grafana-tls
+            hosts:
+              - grafana.dublinconsulting.com.br
+        sidecar:
+          alerts:
+            enabled: true
+          dashboards:
+            enabled: true
+          datasources:
+            enabled: true
+          plugins:
+            enabled: true
+          notifiers:
+            enabled: true
+    chart: infra/grafana
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true


### PR DESCRIPTION
- Introduced 'grafana.yaml' to deploy Grafana with Helm, including ingress settings and sidecar configurations for alerts, dashboards, and datasources.
- Added 'grafana-config.yaml' for Grafana configuration management, specifying the source repository and project details for ArgoCD.