### PR TITLE
Add trivy-operator application to ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy-operator
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: harbor.guiadodevops.com
+    targetRevision: 0.29.3
+    chart: infra/trivy-operator
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true


### PR DESCRIPTION
- Introduced 'trivy-operator.yaml' to deploy the Trivy Operator for security scanning within the ArgoCD core-tools project.
- Configured automated sync policies and specified the source repository and destination namespace for deployment.