### PR TITLE
Add Trivy Operator configuration files for ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/config/trivy-operator-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/trivy-operator-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy-operator-config
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
+    targetRevision: HEAD
+    path: kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true 

--- a/kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config/trivy-operator-servicemonitor.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config/trivy-operator-servicemonitor.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trivy-operator
+  namespace: monitoring
+  labels:
+    app: trivy-operator
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/version: "0.29.3"
+    app.kubernetes.io/managed-by: Helm
+    release: trivy-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+      app.kubernetes.io/instance: trivy-operator
+  namespaceSelector:
+    matchNames:
+      - security
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: 'trivy_operator_.*'
+          action: keep 


### PR DESCRIPTION
- Introduced 'trivy-operator-config.yaml' to define the Trivy Operator application in ArgoCD, specifying the source repository and automated sync policies.
- Added 'trivy-operator-servicemonitor.yaml' to create a ServiceMonitor for the Trivy Operator, enabling metrics scraping for monitoring purposes.