### PR TITLE
Refactor Kube-Prometheus-Stack and add Trivy Operator configurations

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/config/trivy-operator-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/trivy-operator-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy-operator-config
+  namespace: argocd     
+spec:
+  project: core-tools
+  source:
+    repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
+    targetRevision: HEAD
+    path: kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true 
+      selfHeal: true 

--- a/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
@@ -44,17 +44,9 @@ spec:
               limits:
                 memory: 2Gi
                 cpu: 1000m
-            additionalScrapeConfigs:
-              - job_name: 'trivy-operator'
-                static_configs:
-                  - targets: ['trivy-operator.security.svc.cluster.local:80']
-                metrics_path: '/metrics'
-                scrape_interval: 30s
-                scrape_timeout: 10s
-                relabel_configs:
-                  - source_labels: [__name__]
-                    regex: 'trivy_operator_.*'
-                    action: keep
+            serviceMonitorSelectorNilUsesHelmValues: false
+            serviceMonitorSelector: {}
+            serviceMonitorNamespaceSelector: {}
         nodeExporter:
           enabled: true
         server:
@@ -65,7 +57,7 @@ spec:
             limits:
               memory: 2Gi
               cpu: 1000m
-    chart: prometheus
+    chart: kube-prometheus-stack
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring

--- a/kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config/trivy-operator-servicemonitor.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/trivy-operator-config/trivy-operator-servicemonitor.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trivy-operator
+  namespace: monitoring
+  labels:
+    app: trivy-operator
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/version: "0.29.3"
+    app.kubernetes.io/managed-by: Helm
+    release: trivy-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+      app.kubernetes.io/instance: trivy-operator
+  namespaceSelector:
+    matchNames:
+      - security
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: 'trivy_operator_.*'
+          action: keep 


### PR DESCRIPTION
- Removed additional scrape configurations for the Trivy Operator from the Kube-Prometheus-Stack.
- Updated the chart reference to 'kube-prometheus-stack'.
- Introduced 'trivy-operator-config.yaml' to define the Trivy Operator application in ArgoCD with automated sync policies.
- Added 'trivy-operator-servicemonitor.yaml' to create a ServiceMonitor for the Trivy Operator, enabling metrics scraping.