### PR TITLE
Update kube-prometheus-stack to version 60.1.0 and enhance configuration

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
@@ -7,7 +7,7 @@ spec:
   project: core-tools
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 25.0.0
+    targetRevision: 60.1.0
     helm:
       values: |-
         alertmanager:
@@ -49,14 +49,19 @@ spec:
             serviceMonitorNamespaceSelector: {}
         nodeExporter:
           enabled: true
-        server:
-          resources:
-            requests:
-              memory: 750Mi
-              cpu: 500m
-            limits:
-              memory: 2Gi
-              cpu: 1000m
+        defaultRules:
+          create: true
+        kube-state-metrics:
+          enabled: true
+        prometheus-node-exporter:
+          enabled: true
+        prometheus-pushgateway:
+          enabled: false
+        prometheusOperator:
+          admissionWebhooks:
+            enabled: false
+          tls:
+            enabled: false
     chart: kube-prometheus-stack
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
- Updated the target revision of the kube-prometheus-stack to 60.1.0.
- Enabled default rules and kube-state-metrics.
- Configured prometheus-node-exporter and prometheus-pushgateway settings.
- Disabled admission webhooks and TLS for prometheusOperator.