### PR TITLE
Update Grafana storage configuration to allow ReadWriteMany access mode

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
@@ -29,7 +29,7 @@ spec:
           storageClassName: "oci-bv"
           size: 10Gi
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
         sidecar:
           alerts:
             enabled: true


### PR DESCRIPTION
- Changed the access mode for Grafana's persistent storage from ReadWriteOnce to ReadWriteMany, enabling shared access across multiple pods.