### PR TITLE
Enhance kube-prometheus-stack and trivy-operator configurations

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
@@ -26,6 +26,8 @@ spec:
           enabled: false
         prometheus:
           prometheusSpec:
+            serviceMonitorSelector: {}
+            serviceMonitorNamespaceSelector: {}
             replicas: 1
             storageSpec:
               volumeClaimTemplate:
@@ -54,17 +56,6 @@ spec:
             limits:
               memory: 2Gi
               cpu: 1000m
-        additionalScrapeConfigs:
-          - job_name: 'trivy-operator'
-            static_configs:
-              - targets: ['trivy-operator.security.svc.cluster.local:80']
-            metrics_path: '/metrics'
-            scrape_interval: 30s
-            scrape_timeout: 10s
-            relabel_configs:
-              - source_labels: [__name__]
-                regex: 'trivy_operator_.*'
-                action: keep
     chart: prometheus
   destination:
     server: https://kubernetes.default.svc

--- a/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
@@ -9,6 +9,19 @@ spec:
     repoURL: harbor.guiadodevops.com
     targetRevision: 0.29.3
     chart: infra/trivy-operator
+    helm:
+      values: |-
+        operator:
+          metrics:
+            enabled: true
+        prometheus:
+          serviceMonitor:
+            enabled: true
+            labels:
+              release: prometheus
+          rules:
+            enabled: true
+            namespace: monitoring    
   destination:
     server: https://kubernetes.default.svc
     namespace: security


### PR DESCRIPTION
- Added serviceMonitorSelector and serviceMonitorNamespaceSelector to kube-prometheus-stack for improved service monitoring.
- Enabled metrics and Prometheus integration for the Trivy Operator, including rules configuration for the monitoring namespace.