### PR TITLE
Remove unnecessary namespace specification from Trivy Operator rules …

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
@@ -21,7 +21,6 @@ spec:
               release: prometheus
           rules:
             enabled: true
-            namespace: monitoring    
   destination:
     server: https://kubernetes.default.svc
     namespace: security


### PR DESCRIPTION
…in trivy-operator.yaml