### PR TITLE
Update kube-prometheus-stack and trivy-operator configurations

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/kube-prometheus-stack.yaml
@@ -27,7 +27,10 @@ spec:
         prometheus:
           prometheusSpec:
             serviceMonitorSelector: {}
-            serviceMonitorNamespaceSelector: {}
+            serviceMonitorNamespaceSelector:
+              matchNames:
+                - monitoring
+                - security
             replicas: 1
             storageSpec:
               volumeClaimTemplate:

--- a/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
@@ -17,8 +17,10 @@ spec:
         prometheus:
           serviceMonitor:
             enabled: true
+            namespace: monitoring
             labels:
-              release: prometheus
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: prometheus
           rules:
             enabled: true
   destination:


### PR DESCRIPTION
- Added specific namespaces for serviceMonitorNamespaceSelector in kube-prometheus-stack to enhance monitoring capabilities.
- Updated labels in trivy-operator to include app.kubernetes.io/name and app.kubernetes.io/instance for better identification and organization.