### PR TITLE
Add metricsPort configuration for Trivy Operator service

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/trivy-operator.yaml
@@ -14,6 +14,8 @@ spec:
         operator:
           metrics:
             enabled: true
+        service:
+          metricsPort: 8080
         prometheus:
           serviceMonitor:
             enabled: true


### PR DESCRIPTION
- Introduced metricsPort set to 8080 in the Trivy Operator configuration to enable metrics exposure on the specified port.