### PR TITLE
Refactor CI/CD workflow to use secrets for DockerHub credentials

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,6 @@ on:
 env:
   IMAGE_NAME: my-app
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
   APP_PATH: kubernetes/argocd_cluster02/config/my-k8s-app/app
   MANIFESTS_PATH: kubernetes/argocd_cluster02/config/my-k8s-app/manifests
 
@@ -28,8 +27,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Get short SHA
         id: vars
@@ -41,12 +40,12 @@ jobs:
           context: ./${{ env.APP_PATH }}
           push: true
           tags: |
-            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.sha_short }}
-            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.sha_short }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Update Deployment image tag
         run: |
-          sed -i "s|image: .*|image: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.sha_short }}|" ${{ env.MANIFESTS_PATH }}/deployment.yaml
+          sed -i "s|image: .*|image: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.sha_short }}|" ${{ env.MANIFESTS_PATH }}/deployment.yaml
 
       - name: Commit and Push manifests
         run: |


### PR DESCRIPTION
- Removed environment variable for DockerHub token and replaced it with GitHub secrets for enhanced security.
- Updated image tag references in the workflow to utilize secrets instead of environment variables.