### PR TITLE
Add AppProject manifest for tools in ArgoCD

### DIFF
--- a/kubernetes/argocd_cluster02/config/tools-project.yaml
+++ b/kubernetes/argocd_cluster02/config/tools-project.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: tools
+  namespace: argocd
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*' 


### PR DESCRIPTION
- Created a new YAML file defining the AppProject for the tools namespace.
- Configured cluster resource access and source repository settings to allow broad permissions.