### PR TITLE
Remove commented-out scanMetadataReportFile line from CI/CD workflow …

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,8 +50,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        with:
-#          scanMetadataReportFile: ${{ env.APP_PATH }}/.scannerwork/report-task.txt
       # If quality gate fails, the job will stop here
 
       # -------------------------


### PR DESCRIPTION
…for SonarQube quality gate step