### PR TITLE
Add GKE cluster configuration with Terraform

### DIFF
--- a/infra-code/terraform/gcp/gke-cluster/.gitignore
+++ b/infra-code/terraform/gcp/gke-cluster/.gitignore
@@ -1,0 +1,74 @@
+## for Terraform
+
+# terraform module
+terraform-provider-aws_v5.98.0_x5
+
+# Terraform state
+*.tfstate
+*.tfstate.backup
+*.tfstate.*
+
+# Crash log
+crash.log
+
+# Ignore terraform plan files
+*.tfplan
+
+# Ignore .terraform directory (where modules and plugins are stored)
+.terraform/
+
+# Ignore override files
+#*.tfvars
+#*.tfvars.json
+
+# Ignore sensitive files
+#terraform.tfvars
+#terraform.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# .terraform.lock.hcl can be committed if using Terraform >= 0.14
+# Uncomment the line below to ignore it (optional)
+.terraform.lock.hcl
+*.pem
+*.ppk
+
+
+
+## Node.js project
+
+# Node modules
+node_modules/
+
+# Logs
+logs/
+*.log
+
+# Environment files
+.env
+
+# Build outputs
+dist/
+build/
+
+# OS-specific
+.DS_Store
+Thumbs.db
+
+# 
+
+__pycache__/
+*.py[cod]
+.env
+*.env
+*.log
+
+## For a Python project
+```
+providers = {
+  oci = oci
+  oci.home = oci
+}
+```

--- a/infra-code/terraform/gcp/gke-cluster/README.md
+++ b/infra-code/terraform/gcp/gke-cluster/README.md
@@ -1,0 +1,55 @@
+# GKE on GCP with Terraform (modular)
+
+This project creates a production-ready GKE cluster using Terraform **modules**,
+with a **GCS remote backend**, **variables**, and **structured outputs**—mirroring
+a modular approach similar to OKE on OCI.
+
+## What it creates
+- A dedicated VPC with subnets and secondary IP ranges for Pods and Services
+- GKE cluster (private by default optional), regular release channel
+- Managed node pool with autoscaling (configure min/max), or fixed size
+- Opinionated logging/monitoring and security hardening (Shielded nodes, Workload Identity)
+- IAM and API enablement (optional toggle)
+- Outputs to fetch kubeconfig
+
+## Prereqs
+- Terraform >= 1.5
+- gcloud CLI authenticated to the target project
+- A GCS bucket for remote state (or use the provided `backend.hcl` + `terraform init -backend-config`)
+
+## How to use
+1. **Enable APIs** (or set `enable_apis = true` to let Terraform do it):
+   ```bash
+   gcloud services enable container.googleapis.com compute.googleapis.com iam.googleapis.com --project <YOUR_PROJECT_ID>
+   ```
+
+2. **Remote state** (recommended):
+   - Create a GCS bucket (once):
+     ```bash
+     gsutil mb -p <YOUR_PROJECT_ID> -l <REGION> gs://<YOUR_BUCKET_NAME>
+     ```
+   - Edit `backend.hcl` with your bucket/prefix and run:
+     ```bash
+     terraform init -backend-config=backend.hcl
+     ```
+
+3. **Plan & apply**:
+   ```bash
+   terraform workspace new dev || terraform workspace select dev
+   terraform plan -var-file=terraform.tfvars
+   terraform apply -auto-approve -var-file=terraform.tfvars
+   ```
+
+4. **Get kubeconfig**:
+   ```bash
+   gcloud container clusters get-credentials $(terraform output -raw cluster_name)      --region $(terraform output -raw cluster_location)      --project $(terraform output -raw project_id)
+   ```
+
+## Destroy
+```bash
+terraform destroy -var-file=terraform.tfvars
+```
+
+## Notes
+- Backend blocks **cannot use variables**. Use `backend.hcl` + `terraform init -backend-config=backend.hcl`.
+- Adjust CIDRs carefully to avoid overlap with on‑prem/other clouds if you use hybrid networking.

--- a/infra-code/terraform/gcp/gke-cluster/backend.hcl
+++ b/infra-code/terraform/gcp/gke-cluster/backend.hcl
@@ -1,0 +1,5 @@
+# Remote state backend config for Terraform (use with: terraform init -backend-config=backend.hcl)
+bucket = "YOUR_GCS_BACKEND_BUCKET_NAME"
+prefix = "terraform/state/gke"
+# Optionally:
+# impersonate_service_account = "tf-backend@YOUR_PROJECT_ID.iam.gserviceaccount.com"

--- a/infra-code/terraform/gcp/gke-cluster/kubernetes_provider.tf
+++ b/infra-code/terraform/gcp/gke-cluster/kubernetes_provider.tf
@@ -1,0 +1,14 @@
+# Configure kubernetes provider using data from the created cluster
+data "google_client_config" "default" {}
+
+data "google_container_cluster" "target" {
+  name     = module.gke.cluster_name
+  location = module.gke.location
+  project  = var.project_id
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.target.endpoint}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.target.master_auth[0].cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}

--- a/infra-code/terraform/gcp/gke-cluster/main.tf
+++ b/infra-code/terraform/gcp/gke-cluster/main.tf
@@ -1,0 +1,53 @@
+# Optional: Enable required APIs (toggle via var.enable_apis)
+resource "google_project_service" "required" {
+  for_each = var.enable_apis ? toset([
+    "container.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+  ]) : []
+  project                    = var.project_id
+  service                    = each.key
+  disable_dependent_services = false
+}
+
+module "network" {
+  source = "./modules/network"
+
+  project_id   = var.project_id
+  network_name = var.network_name
+  region       = var.region
+
+  vpc_cidr               = var.vpc_cidr
+  subnet_ip_cidr_range   = var.subnet_ip_cidr_range
+  pods_secondary_cidr    = var.pods_secondary_cidr
+  services_secondary_cidr= var.services_secondary_cidr
+}
+
+module "gke" {
+  source = "./modules/gke"
+
+  project_id         = var.project_id
+  name               = var.cluster_name
+  location           = var.location
+  network            = module.network.network_self_link
+  subnetwork         = module.network.subnet_self_link
+  pods_range_name    = module.network.pods_range_name
+  services_range_name= module.network.services_range_name
+
+  release_channel    = var.release_channel
+  kubernetes_version = var.kubernetes_version
+
+  enable_private_nodes = var.enable_private_nodes
+  enable_private_endpoint = var.enable_private_endpoint
+  master_ipv4_cidr_block = var.master_ipv4_cidr_block
+
+  logging_config     = var.logging_config
+  monitoring_config  = var.monitoring_config
+
+  workload_identity  = var.workload_identity
+
+  node_pools = var.node_pools
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/gke/main.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/gke/main.tf
@@ -1,0 +1,111 @@
+resource "google_container_cluster" "this" {
+  name     = var.name
+  location = var.location
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  dynamic "binary_authorization" {
+    for_each = []
+    content {}
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.pods_range_name
+    services_secondary_range_name = var.services_range_name
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = var.enable_private_nodes
+    enable_private_endpoint = var.enable_private_endpoint
+    master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+  }
+
+  workload_identity_config {
+    workload_pool = var.workload_identity ? "${var.project_id}.svc.id.goog" : null
+  }
+
+  logging_config {
+    enable_components = compact([
+      var.logging_config.enable_system_logs ? "SYSTEM_COMPONENTS" : "",
+      var.logging_config.enable_workloads_logs ? "WORKLOADS" : "",
+    ])
+  }
+
+  monitoring_config {
+    enable_components = compact([
+      var.monitoring_config.enable_system_metrics ? "SYSTEM_COMPONENTS" : "",
+      var.monitoring_config.enable_workloads_metrics ? "WORKLOADS" : "",
+    ])
+  }
+
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
+
+  vertical_pod_autoscaling {
+    enabled = true
+  }
+
+  lifecycle {
+    ignore_changes = [node_config] # since we're using separate node_pools
+  }
+}
+
+# Create one node pool per entry
+resource "google_container_node_pool" "pools" {
+  for_each = var.node_pools
+
+  name       = "${var.name}-${each.key}"
+  location   = var.location
+  cluster    = google_container_cluster.this.name
+
+  initial_node_count = max(each.value.min_count, 1)
+
+  autoscaling {
+    min_node_count = each.value.min_count
+    max_node_count = each.value.max_count
+  }
+
+  management {
+    auto_repair  = each.value.auto_repair
+    auto_upgrade = each.value.auto_upgrade
+  }
+
+  node_config {
+    machine_type = each.value.machine_type
+    disk_size_gb = each.value.disk_size_gb
+    disk_type    = each.value.disk_type
+
+    preemptible  = each.value.preemptible
+    spot         = each.value.spot
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+
+    labels = each.value.labels
+    tags   = each.value.tags
+
+    dynamic "taint" {
+      for_each = each.value.taints
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+
+    shielded_instance_config {
+      enable_secure_boot = true
+    }
+  }
+
+  depends_on = [google_container_cluster.this]
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/gke/outputs.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/gke/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "location" {
+  value = google_container_cluster.this.location
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/gke/variables.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/gke/variables.tf
@@ -1,0 +1,80 @@
+variable "project_id"        { type = string }
+variable "name"              { type = string }
+variable "location"          { type = string }
+variable "network"           { type = string }
+variable "subnetwork"        { type = string }
+variable "pods_range_name"   { type = string }
+variable "services_range_name" { type = string }
+
+variable "kubernetes_version" {
+  type    = string
+  default = null
+}
+
+variable "release_channel" {
+  type    = string
+  default = "REGULAR"
+}
+
+variable "enable_private_nodes" {
+  type    = bool
+  default = true
+}
+
+variable "enable_private_endpoint" {
+  type    = bool
+  default = false
+}
+
+variable "master_ipv4_cidr_block" {
+  type    = string
+  default = "172.16.0.0/28"
+}
+
+variable "logging_config" {
+  type = object({
+    enable_system_logs     = bool
+    enable_workloads_logs  = bool
+  })
+  default = {
+    enable_system_logs    = true
+    enable_workloads_logs = true
+  }
+}
+
+variable "monitoring_config" {
+  type = object({
+    enable_system_metrics     = bool
+    enable_workloads_metrics  = bool
+  })
+  default = {
+    enable_system_metrics    = true
+    enable_workloads_metrics = true
+  }
+}
+
+variable "workload_identity" {
+  type    = bool
+  default = true
+}
+
+variable "node_pools" {
+  type = map(object({
+    machine_type   = string
+    min_count      = number
+    max_count      = number
+    disk_size_gb   = number
+    disk_type      = string
+    preemptible    = bool
+    spot           = bool
+    auto_upgrade   = bool
+    auto_repair    = bool
+    tags           = list(string)
+    labels         = map(string)
+    taints         = list(object({
+      key    = string
+      value  = string
+      effect = string
+    }))
+  }))
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/network/main.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/network/main.tf
@@ -1,0 +1,49 @@
+resource "google_compute_network" "vpc" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.network_name}-subnet"
+  ip_cidr_range = var.subnet_ip_cidr_range
+  region        = var.region
+  network       = google_compute_network.vpc.id
+
+  secondary_ip_range {
+    range_name    = "${var.network_name}-pods"
+    ip_cidr_range = var.pods_secondary_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = "${var.network_name}-services"
+    ip_cidr_range = var.services_secondary_cidr
+  }
+}
+
+# Minimal firewall rules (adjust to your needs)
+resource "google_compute_firewall" "internal" {
+  name    = "${var.network_name}-allow-internal"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "all"
+  }
+
+  source_ranges = [var.vpc_cidr]
+}
+
+resource "google_compute_router" "router" {
+  name    = "${var.network_name}-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.network_name}-nat"
+  region                             = var.region
+  router                             = google_compute_router.router.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  enable_endpoint_independent_mapping = true
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/network/outputs.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/network/outputs.tf
@@ -1,0 +1,23 @@
+output "network_self_link" {
+  value = google_compute_network.vpc.self_link
+}
+
+output "network_name" {
+  value = google_compute_network.vpc.name
+}
+
+output "subnet_self_link" {
+  value = google_compute_subnetwork.subnet.self_link
+}
+
+output "subnet_name" {
+  value = google_compute_subnetwork.subnet.name
+}
+
+output "pods_range_name" {
+  value = google_compute_subnetwork.subnet.secondary_ip_range[0].range_name
+}
+
+output "services_range_name" {
+  value = google_compute_subnetwork.subnet.secondary_ip_range[1].range_name
+}

--- a/infra-code/terraform/gcp/gke-cluster/modules/network/variables.tf
+++ b/infra-code/terraform/gcp/gke-cluster/modules/network/variables.tf
@@ -1,0 +1,8 @@
+variable "project_id" { type = string }
+variable "network_name" { type = string }
+variable "region" { type = string }
+
+variable "vpc_cidr" { type = string }
+variable "subnet_ip_cidr_range" { type = string }
+variable "pods_secondary_cidr" { type = string }
+variable "services_secondary_cidr" { type = string }

--- a/infra-code/terraform/gcp/gke-cluster/outputs.tf
+++ b/infra-code/terraform/gcp/gke-cluster/outputs.tf
@@ -1,0 +1,22 @@
+output "project_id" {
+  value       = var.project_id
+  description = "GCP project id"
+}
+
+output "cluster_name" {
+  value       = module.gke.cluster_name
+  description = "GKE cluster name"
+}
+
+output "cluster_location" {
+  value       = module.gke.location
+  description = "GKE cluster location"
+}
+
+output "network_name" {
+  value = module.network.network_name
+}
+
+output "subnet_name" {
+  value = module.network.subnet_name
+}

--- a/infra-code/terraform/gcp/gke-cluster/provider.tf
+++ b/infra-code/terraform/gcp/gke-cluster/provider.tf
@@ -1,0 +1,12 @@
+# Providers configured from variables
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# K8s provider configured after cluster creation using outputs (see kubernetes_provider.tf)

--- a/infra-code/terraform/gcp/gke-cluster/terraform.tfvars
+++ b/infra-code/terraform/gcp/gke-cluster/terraform.tfvars
@@ -1,0 +1,32 @@
+project_id = "your-project-id"
+region    = "us-central1"
+location  = "us-central1"
+
+network_name = "vpc-gke"
+vpc_cidr     = "10.10.0.0/16"
+
+# Node subnet (nodes)
+subnet_ip_cidr_range    = "10.10.0.0/20"
+# Secondary ranges (pods/services)
+pods_secondary_cidr     = "10.20.0.0/14"
+services_secondary_cidr = "10.30.0.0/20"
+
+cluster_name = "gke-primary"
+
+# Example node pool config similar to OKE fixed pool (min=max=2)
+node_pools = {
+  default = {
+    machine_type = "e2-standard-4"
+    min_count    = 2
+    max_count    = 2
+    disk_size_gb = 100
+    disk_type    = "pd-standard"
+    preemptible  = false
+    spot         = false
+    auto_upgrade = true
+    auto_repair  = true
+    tags         = ["gke-nodes"]
+    labels       = { "role" = "general" }
+    taints       = []
+  }
+}

--- a/infra-code/terraform/gcp/gke-cluster/variables.tf
+++ b/infra-code/terraform/gcp/gke-cluster/variables.tf
@@ -1,0 +1,154 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "region" {
+  type        = string
+  description = "Default region for regional resources"
+  default     = "us-central1"
+}
+
+variable "location" {
+  type        = string
+  description = "GKE location (region or zone). Example: us-central1"
+  default     = "us-central1"
+}
+
+variable "network_name" {
+  type        = string
+  description = "Name of the VPC"
+  default     = "vpc-gke"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "Primary VPC CIDR (for reference / firewall)"
+  default     = "10.10.0.0/16"
+}
+
+variable "subnet_ip_cidr_range" {
+  type        = string
+  description = "Subnet primary CIDR for nodes"
+  default     = "10.10.0.0/20"
+}
+
+variable "pods_secondary_cidr" {
+  type        = string
+  description = "Secondary range CIDR for Pods"
+  default     = "10.20.0.0/14"
+}
+
+variable "services_secondary_cidr" {
+  type        = string
+  description = "Secondary range CIDR for Services"
+  default     = "10.30.0.0/20"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name"
+  default     = "gke-primary"
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "GKE version (blank = latest on channel)"
+  default     = null
+}
+
+variable "release_channel" {
+  type        = string
+  description = "GKE release channel: RAPID | REGULAR | STABLE"
+  default     = "REGULAR"
+}
+
+variable "enable_private_nodes" {
+  type        = bool
+  description = "Whether to use private nodes"
+  default     = true
+}
+
+variable "enable_private_endpoint" {
+  type        = bool
+  description = "If true, control plane endpoint is internal only"
+  default     = false
+}
+
+variable "master_ipv4_cidr_block" {
+  type        = string
+  description = "CIDR for the master authorized network/control plane (only when private)"
+  default     = "172.16.0.0/28"
+}
+
+variable "logging_config" {
+  type = object({
+    enable_system_logs  = bool
+    enable_workloads_logs = bool
+  })
+  default = {
+    enable_system_logs    = true
+    enable_workloads_logs = true
+  }
+}
+
+variable "monitoring_config" {
+  type = object({
+    enable_system_metrics   = bool
+    enable_workloads_metrics= bool
+  })
+  default = {
+    enable_system_metrics    = true
+    enable_workloads_metrics = true
+  }
+}
+
+variable "workload_identity" {
+  type        = bool
+  description = "Enable Workload Identity (recommended)"
+  default     = true
+}
+
+variable "node_pools" {
+  description = "Map of node pool configs"
+  type = map(object({
+    machine_type   = string
+    min_count      = number
+    max_count      = number
+    disk_size_gb   = number
+    disk_type      = string
+    preemptible    = bool
+    spot           = bool
+    auto_upgrade   = bool
+    auto_repair    = bool
+    tags           = list(string)
+    labels         = map(string)
+    taints         = list(object({
+      key    = string
+      value  = string
+      effect = string # NO_SCHEDULE, PREFER_NO_SCHEDULE, NO_EXECUTE
+    }))
+  }))
+  default = {
+    default = {
+      machine_type = "e2-standard-4"
+      min_count    = 2
+      max_count    = 2
+      disk_size_gb = 100
+      disk_type    = "pd-standard"
+      preemptible  = false
+      spot         = false
+      auto_upgrade = true
+      auto_repair  = true
+      tags         = ["gke-nodes"]
+      labels       = {}
+      taints       = []
+    }
+  }
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Enable required Google APIs"
+  default     = true
+}

--- a/infra-code/terraform/gcp/gke-cluster/versions.tf
+++ b/infra-code/terraform/gcp/gke-cluster/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.30.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 5.30.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.31.0"
+    }
+  }
+  backend "gcs" {} # configure via backend.hcl
+}


### PR DESCRIPTION
- Created a modular setup for deploying a GKE cluster on GCP.
- Added necessary Terraform files including main.tf, variables.tf, and outputs.tf.
- Configured network and node pool modules for VPC and GKE settings.
- Implemented remote state management with GCS backend.
- Included a README for setup instructions and prerequisites.