### PR TITLE
Add annotation to argocd-rollouts application for extraneous comparison

### DIFF
--- a/kubernetes/argocd_cluster02/applications/tools/argocd-rollouts.yaml
+++ b/kubernetes/argocd_cluster02/applications/tools/argocd-rollouts.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: argocd-rollouts
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   project: tools
   source:


### PR DESCRIPTION
- Added an annotation to the argocd-rollouts YAML configuration to ignore extraneous differences during comparison in ArgoCD.