### PR TITLE
Refactor deployment configuration to use Argo Rollouts

### DIFF
--- a/kubernetes/argocd_cluster02/config/my-k8s-app/manifests/deployment.yaml
+++ b/kubernetes/argocd_cluster02/config/my-k8s-app/manifests/deployment.yaml
@@ -1,10 +1,11 @@
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
 metadata:
   name: my-app
 spec:
-  replicas: 1
+  replicas: 2
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: my-app
@@ -18,24 +19,14 @@ spec:
           image: docker.io/flaviorssilva/my-app:26a5907
           ports:
             - containerPort: 3000
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: my-app
-  template:
-    metadata:
-      labels:
-        app: my-app
-    spec:
-      containers:
-        - name: my-app
-          image: docker.io/flaviorssilva/my-app:26a5907
-          ports:
-            - containerPort: 3000
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20
+        - pause:
+            duration: 30s
+        - setWeight: 50
+        - pause:
+            duration: 30s
+        - setWeight: 100
 


### PR DESCRIPTION
- Changed the resource kind from Deployment to Rollout for enhanced deployment strategies.
- Increased replica count from 1 to 2 and set revision history limit to 2.
- Added a canary deployment strategy with defined weight steps and pauses for gradual rollout.