### PR TITLE
Update Istio configuration path in Argo CD application manifest

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/config/istio-config.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/config/istio-config.yaml
@@ -7,7 +7,7 @@ spec:
   project: core-tools-config
   source:
     repoURL: https://github.com/flaviorssilva1981/guiadodevops.git
-    path: kubernetes/argocd_cluster02/config/core-tools/istio-config
+    path: kubernetes/argocd_cluster02/config/istio
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
- Changed the path in the Istio configuration from `kubernetes/argocd_cluster02/config/core-tools/istio-config` to `kubernetes/argocd_cluster02/config/istio` for improved organization and clarity.