### PR TITLE
Update replica counts and revision history limits for frontend and my…

### DIFF
--- a/kubernetes/argocd_cluster02/config/boutique-app/frontend-rollout.yaml
+++ b/kubernetes/argocd_cluster02/config/boutique-app/frontend-rollout.yaml
@@ -3,7 +3,7 @@ kind: Rollout
 metadata:
   name: frontend
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: frontend

--- a/kubernetes/argocd_cluster02/config/my-k8s-app/manifests/deployment.yaml
+++ b/kubernetes/argocd_cluster02/config/my-k8s-app/manifests/deployment.yaml
@@ -4,8 +4,8 @@ kind: Rollout
 metadata:
   name: my-app
 spec:
-  replicas: 10
-  revisionHistoryLimit: 3
+  replicas: 2
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: my-app


### PR DESCRIPTION
…-app deployments

- Reduced the replica count from 3 to 2 for the frontend rollout to optimize resource usage.
- Adjusted the replica count from 10 to 2 and the revision history limit from 3 to 2 for my-app deployment to enhance management and efficiency.