### PR TITLE
Adjust Istio autoscaling configuration in istiod.yaml

### DIFF
--- a/kubernetes/argocd_cluster02/applications/istio/istiod.yaml
+++ b/kubernetes/argocd_cluster02/applications/istio/istiod.yaml
@@ -14,7 +14,7 @@ spec:
     helm:
       values: |
         pilot:
-          autoscaleMin: 2
+          autoscaleMin: 1
         meshConfig:
           accessLogFile: /dev/stdout
   destination:


### PR DESCRIPTION
- Reduced the autoscale minimum from 2 to 1 to optimize resource allocation for the Istio control plane.