### PR TITLE
Enhance Istio autoscaling settings in ingress and istiod configurations

### DIFF
--- a/kubernetes/argocd_cluster02/applications/istio/istio-ingress.yaml
+++ b/kubernetes/argocd_cluster02/applications/istio/istio-ingress.yaml
@@ -19,6 +19,9 @@ spec:
         image: docker.io/istio/proxyv2:1.23.0
         podAnnotations:
           sidecar.istio.io/proxyImage: docker.io/istio/proxyv2:1.23.0
+        autoscaling:
+          enabled: false
+          minReplicas: 1
         service:
           type: LoadBalancer
           annotations:

--- a/kubernetes/argocd_cluster02/applications/istio/istiod.yaml
+++ b/kubernetes/argocd_cluster02/applications/istio/istiod.yaml
@@ -15,6 +15,8 @@ spec:
       values: |
         pilot:
           autoscaleMin: 1
+          autoscaleEnabled: false
+          replicaCount: 1
         meshConfig:
           accessLogFile: /dev/stdout
   destination:


### PR DESCRIPTION
- Disabled autoscaling for the Istio ingress and set minimum replicas to 1 for better resource management.
- Updated istiod configuration to disable autoscaling and set replica count to 1, ensuring consistent performance.