### PR TITLE
Add ignoreDifferences for ValidatingWebhookConfiguration in Istio bas…

### DIFF
--- a/kubernetes/argocd_cluster02/applications/istio/istio-base.yaml
+++ b/kubernetes/argocd_cluster02/applications/istio/istio-base.yaml
@@ -11,6 +11,12 @@ spec:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
     targetRevision: 1.23.0
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: istiod-default-validator
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
   destination:
     server: https://kubernetes.default.svc
     namespace: istio-system


### PR DESCRIPTION
…e configuration

- Introduced an ignoreDifferences setting for the ValidatingWebhookConfiguration named istiod-default-validator to prevent unnecessary updates related to the caBundle field in the Istio base configuration.