### PR TITLE
Update TLS credential name in frontend virtual service for boutique app

### DIFF
--- a/kubernetes/argocd_cluster02/config/boutique-app/frontend-vs.yaml
+++ b/kubernetes/argocd_cluster02/config/boutique-app/frontend-vs.yaml
@@ -27,7 +27,7 @@ spec:
         - boutique.dublinconsulting.com.br
       tls:
         mode: SIMPLE
-        secretName: boutique-tls
+        credentialName: tls-boutique
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
@@ -45,3 +45,4 @@ spec:
             host: frontend-active.boutique.svc.cluster.local
             port:
               number: 80
+##test


### PR DESCRIPTION
- Changed the TLS configuration from 'secretName' to 'credentialName' to align with the latest Istio standards.
- Ensured the TLS mode remains set to SIMPLE for secure communication.