### PR TITLE
Update OKE cluster worker pool size and add environment variables for…

### DIFF
--- a/infra-code/terraform/oci/oke-cluster/main.tf
+++ b/infra-code/terraform/oci/oke-cluster/main.tf
@@ -26,7 +26,7 @@ module "oke_cluster" {
   # Worker pool configuration
   worker_pools = {
     "default-pool" = {
-      size = 2
+      size = 3
       shape = "VM.Standard.E4.Flex"
       ocpus = 2
       memory = 16

--- a/kubernetes/argocd_cluster02/config/boutique-app/currencyservice.yaml
+++ b/kubernetes/argocd_cluster02/config/boutique-app/currencyservice.yaml
@@ -18,4 +18,13 @@ spec:
           image: gcr.io/google-samples/microservices-demo/currencyservice:v0.8.0
           ports:
             - containerPort: 7000
+          env:
+            - name: PORT
+              value: "7000"
+            - name: DISABLE_TRACING
+              value: "1"
+            - name: DISABLE_PROFILER
+              value: "1"
+            - name: DISABLE_DEBUGGER
+              value: "1"
 

--- a/kubernetes/argocd_cluster02/config/boutique-app/paymentservice.yaml
+++ b/kubernetes/argocd_cluster02/config/boutique-app/paymentservice.yaml
@@ -18,4 +18,13 @@ spec:
           image: gcr.io/google-samples/microservices-demo/paymentservice:v0.8.0
           ports:
             - containerPort: 50051
+          env:
+            - name: PORT
+              value: "50051"
+            - name: DISABLE_TRACING
+              value: "1"
+            - name: DISABLE_PROFILER
+              value: "1"
+            - name: DISABLE_DEBUGGER
+              value: "1"
 


### PR DESCRIPTION
… currency and payment services

- Increased the worker pool size from 2 to 3 in the OKE cluster configuration.
- Added environment variables for the currencyservice and paymentservice to enhance service configuration, including PORT, DISABLE_TRACING, DISABLE_PROFILER, and DISABLE_DEBUGGER.