### PR TITLE
Add ExternalSecret configuration for Cloudflare API in cert-manager

### DIFF
--- a/kubernetes/argocd_cluster02/config/core-tools/cert-manager-config/cloudflare-api-external-secret.yaml
+++ b/kubernetes/argocd_cluster02/config/core-tools/cert-manager-config/cloudflare-api-external-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-dns-provider-cloudflare
+  namespace: cert-manager
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: external-dns-provider-cloudflare
+  dataFrom:
+    - extract:
+        key: external-dns-provider-cloudflare
+


### PR DESCRIPTION
- Introduced a new ExternalSecret resource for managing Cloudflare API credentials.
- Configured to refresh every 15 seconds and reference a ClusterSecretStore named 'vault'.
- Targeted secret name is 'external-dns-provider-cloudflare' for external DNS integration.