### PR TITLE
Update frontend ingress configuration for boutique app

### DIFF
--- a/kubernetes/argocd_cluster02/config/boutique-app/frontend-ingress.yaml
+++ b/kubernetes/argocd_cluster02/config/boutique-app/frontend-ingress.yaml
@@ -20,6 +20,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: frontend-active
+                name: frontend
                 port:
                   number: 80


### PR DESCRIPTION
- Changed the backend service name from 'frontend-active' to 'frontend' in the ingress configuration to align with the current service naming conventions.