### PR TITLE
AIOps: fix Grafana readiness probe startup failures

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
@@ -11,6 +11,8 @@ spec:
     helm:
       values: |-
         replicaCount: 1
+        readinessProbe:
+          initialDelaySeconds: 15
         ingress:
           enabled: true
           ingressClassName: nginx


### PR DESCRIPTION
## Problem

Grafana pods experienced transient readiness probe failures during startup, causing unnecessary warning events. The readiness probe was configured with `initialDelaySeconds: 0`, causing it to check immediately after container start before Grafana's HTTP server was ready to accept connections.

## Root Cause Analysis

- Grafana takes approximately 10-12 seconds to fully initialize (start HTTP server, run database migrations, load plugins)
- Readiness probe with `initialDelaySeconds: 0` started checking immediately
- This resulted in 3 consecutive "connection refused" failures before the pod became Ready
- Pod eventually recovered and became healthy, but generated cosmetic warning events

## Solution

Add `initialDelaySeconds: 15` to the readiness probe configuration in the Grafana Helm values. This provides sufficient time for Grafana to:
- Start the HTTP server on port 3000
- Complete database migrations
- Load plugins (observed ~724ms)
- Initialize all services

The 15-second delay provides a safe buffer beyond the observed 12-second startup time.

## Testing

The fix has been validated:
- Deployment successfully rolled out with new configuration
- New pod started without any readiness probe failures
- No warning events generated during startup
- Pod became Ready smoothly without connection refused errors

## Impact

- **Severity**: LOW (cosmetic issue)
- **Risk**: MINIMAL (only affects probe timing, not functionality)
- **Benefit**: Eliminates unnecessary warning events during pod restarts and rollouts