### PR TITLE
fix(grafana): use Recreate strategy for RWO PVC multi-attach

### DIFF
--- a/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
+++ b/kubernetes/argocd_cluster02/applications/core-tools/grafana.yaml
@@ -11,6 +11,9 @@ spec:
     helm:
       values: |-
         replicaCount: 1
+        # RWO PVC (oci-bv) cannot multi-attach across nodes during RollingUpdate
+        deploymentStrategy:
+          type: Recreate
         readinessProbe:
           initialDelaySeconds: 15
         ingress:


### PR DESCRIPTION
## Summary
- Set Grafana Helm `deploymentStrategy.type: Recreate` so RWO `oci-bv` PVC is released before the new pod starts
- Prevents recurring `Init:0/1` / multi-attach / `ProgressDeadlineExceeded` on Argo secret/config syncs

## Context
Today Grafana was stuck with two ReplicaSets fighting over PVC `monitoring/grafana` (RWO). Manual recovery: delete old pod to free volume.

## Test plan
- [ ] Merge → app-of-apps syncs Application `grafana`
- [ ] Confirm Deployment strategy becomes `Recreate`
- [ ] Trigger a harmless sync (or wait for next secret checksum change) and verify no Pending multi-attach pod